### PR TITLE
Update sse_mathfun.h

### DIFF
--- a/sse_mathfun.h
+++ b/sse_mathfun.h
@@ -330,9 +330,9 @@ static inline v4sf log_ps(v4sf x)
 	  v4sf z, y;
 	  v4sf mask = _mm_cmplt_ps(x, *(v4sf*)_ps_cephes_SQRTHF);
 	  v4sf tmp = _mm_and_ps(x, mask);
-	  x = _mm_sub_ps(x, one);
 	  e = _mm_sub_ps(e, _mm_and_ps(one, mask));
 	  x = _mm_add_ps(x, tmp);
+	  x = _mm_sub_ps(x, one);
 
 
 	  z = _mm_mul_ps(x,x);


### PR DESCRIPTION
I am not an expert in this subject area, so please excuse me if this pull request is a mistake. However, upon reviewing the code, the comment claims to calculate:

```
if( x < SQRTHF ) {
    e -= 1;
    x = x + x - 1.0;
} else { x = x - 1.0; }
```
And the above code would match the intention from the logf.c code in the cephes library.

However, it appears to actually calculate:
```
if( x < SQRTHF ) {
    e -= 1;
    x = (x-1.0) + (x-1.0);
} else { x = x - 1.0; }
```
Because `1` is subtracted from `x` early in the code.

Again, I am not an expert in this kind of maths & SSE so I apologize if this is due to my misunderstanding, but I thought I would bring it up regardless.